### PR TITLE
Add 8-bit retro theme with animated background and side GIFs

### DIFF
--- a/www/css/settings.css
+++ b/www/css/settings.css
@@ -1,8 +1,12 @@
 body {
-	margin: 0;
-	font-family: 'Roboto', 'Noto Sans TC', sans-serif;
-	background-color: #121212; /* Dark background */
-	color: #ffffff; /* 提高對比度，使用純白字體 */
+            margin: 0;
+            font-family: 'Roboto', 'Noto Sans TC', sans-serif;
+            background-color: #121212; /* Dark background */
+            color: #ffffff; /* 提高對比度，使用純白字體 */
+            background-image: url('https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExZjNxeGR6dmQxbzZycWd5aHYzYTBoNmdza25oMHl6YzdpaGx5aWI3ZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l3vRnoppYtfEbemBO/giphy.gif');
+            background-repeat: repeat;
+            background-size: auto;
+            background-attachment: fixed;
 }
 
 .container {
@@ -325,4 +329,21 @@ a:hover {
 ::-moz-selection {
   background: #bb86fc;
   color: #121212;
+}
+
+.side-gif {
+    position: fixed;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 100px;
+    height: auto;
+    z-index: 5;
+}
+
+.left-gif {
+    left: 20px;
+}
+
+.right-gif {
+    right: 20px;
 }

--- a/www/settings.html
+++ b/www/settings.html
@@ -8,7 +8,6 @@
   <script src="dist/bootstrap/bootstrap.min.js"></script>
   <script src="dist/jquery.min.js"></script>
   <link rel="stylesheet" type="text/css" href="css/settings.css" />
-  <link rel="stylesheet" type="text/css" href="css/8bit-bg.css" />
   <link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png">
   <link rel="icon" href="/favicon-16x16.png" sizes="16x16" type="image/png">
   <link rel="icon" href="/favicon.ico">
@@ -660,6 +659,8 @@
       <p class="text-light" style="font-size: 1.2rem; font-weight: bold; text-shadow: 0 0 5px rgba(255, 255, 255, 0.8);">&copy; 2024-2025 MaxBot HK. All rights reserved.</p>
     </footer>
     </div>
+    <img src="https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExMnFraWVpZXcybGtneGh5Z21ieDY1azI1aXk3MmI0a20wcWs0dXlnZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/DHBGehJ3FSZEygszX3/giphy.gif" class="side-gif left-gif" id="left-planet-gif" alt="Pixel Planet Animation">
+    <img src="https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExZ2QyNXdhNW1jajduOXJrZXVtaThqNDFqZDE2aTVra2xmeGtndW43ZSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/j5mwjor5i5PGigmPH2/giphy.gif" class="side-gif right-gif" id="right-planet-gif" alt="Pixel Planet Animation">
 </body>
 </html>
 


### PR DESCRIPTION
This commit introduces several 8-bit styled visual enhancements to your settings page (www/settings.html):

- A repeating, animated starfield GIF has been added as the main background of the page.
- Two animated pixel planet GIFs are now displayed on the left and right sides of the page as fixed decorative elements, contributing to a "techy arcade" theme.
- The direct URLs for these GIFs are sourced from Giphy.
- A broken link to a non-existent CSS file (8bit-bg.css) was removed from settings.html.

I've tested these changes and confirmed they display correctly, enhancing the visual appeal of the page with a retro aesthetic.